### PR TITLE
Embed CDC agent into Cassandra classpath

### DIFF
--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -35,7 +35,7 @@ RUN mkdir ${MCAC_PATH} && \
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
 
 FROM cassandra:${CASSANDRA_VERSION} as oss40
 

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -34,7 +34,7 @@ RUN mkdir ${MCAC_PATH} && \
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
 
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as netty4150
 RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -88,6 +88,14 @@ if [ "$1" = 'mgmtapi' ]; then
         echo "JVM_OPTS=\"\$JVM_OPTS -javaagent:${MGMT_AGENT_JAR}\"" >> ${CASSANDRA_CONF}/cassandra-env.sh
     fi
 
+    # Add CDC agent
+    CDC_AGENT_JAR="$(find "${CDC_AGENT_PATH}" -name cdc-agent.jar)"
+    if ! grep -qxF "JVM_OPTS=\"\$JVM_OPTS -javaagent:${CDC_AGENT_JAR}\"" < ${CASSANDRA_CONF}/cassandra-env.sh ; then
+        # ensure newline at end of file
+        echo "" >> ${CASSANDRA_CONF}/cassandra-env.sh
+        echo "JVM_OPTS=\"\$JVM_OPTS -javaagent:${CDC_AGENT_JAR}\"" >> ${CASSANDRA_CONF}/cassandra-env.sh
+    fi
+
     # Set this if you want to ignore default env variables, i.e. when running inside an operator
     if [ $IGNORE_DEFAULTS ] || [ $USE_MGMT_API ]; then
         CASSANDRA_RPC_ADDRESS='0.0.0.0'


### PR DESCRIPTION
This should get the agent jar added to the classpath in a similar way we add the MCAC and Management API agents. I'm not fully up to speed on CDC, so there may be some parameters we have to bolt on to the entrypoint script, but I have some ideas on how to do that as well.